### PR TITLE
Fixes #125 - added tel: link to POI phones

### DIFF
--- a/www/js/poi.js
+++ b/www/js/poi.js
@@ -134,7 +134,9 @@ osm.poi = {
       if (!(getdata.phone==null)) {
         phone=$('<tr>').addClass('poi_phone')
           .append($('<td>').text('Телефон: '))
-          .append($('<td>').text(getdata.phone).addClass('poi_value'))
+          .append($('<td>').addClass('poi_value')
+            .append($('<a>').attr('href', 'tel:'+getdata.phone).text(getdata.phone))
+          )
       }
       var fax;
       if (!(getdata.fax==null)) {


### PR DESCRIPTION
Телефоны в POI-ных попапах сделаны ссылками: на мобильных устройствах можно тыкнуть на номер и сразу позвонить.
В #125 решили использовать tel: вместо callto:
