### PR TITLE
Кнопка подробнее, вывод списка значений тега через запятую и скрытие левой панели

### DIFF
--- a/www/css/page.map.css
+++ b/www/css/page.map.css
@@ -305,10 +305,11 @@ a.leaflet-control-distance-active:hover { background-color: #ffa; }
   text-decoration: none;
   border-bottom: 1px solid #999;
 }
-.info_popup .moretags td {
+.info_popup .moretags td,
+.info_popup .moretags th {
   padding: 4px 2px;
   line-height: 1.25em;
-  /*width: 50%;*/
+  vertical-align:top;
 }
 .info_popup > .name {
   color: #000;
@@ -357,7 +358,7 @@ a.leaflet-control-distance-active:hover { background-color: #ffa; }
   color: #666;
   text-decoration: none;
 }
-.info_popup .frame.off {
+.info_popup .moretags .frame.off .poi_moretags:nth-child(n+5) {
   display: none;
 }
 .info_popup .moretags,

--- a/www/js/page.map/osm.utils.js
+++ b/www/js/page.map/osm.utils.js
@@ -211,4 +211,3 @@ osm.mapperMode.changeMode = function() {
     osm.map.removeControl(osm.inJOSM);
   }
 }
-

--- a/www/js/page.map/osm.utils.js
+++ b/www/js/page.map/osm.utils.js
@@ -40,6 +40,8 @@ osm.leftpan.refsizetab = function() {
   if (height < 100)
     height = 100;
   $('#leftpan .leftgroup .leftcontent').css('height', height-12+'px');
+  if (miHeight >= 30)
+    osm.leftpan.toggle(false);
 }
 
 osm.leftpan.item = function(item, on) {

--- a/www/js/page.map/poi.js
+++ b/www/js/page.map/poi.js
@@ -419,7 +419,7 @@ osm.poi = {
     for (xName in getdata.tags_ru) {
       if (getdata.tags_ru[xName]!="неизвестно" && getdata.tags_ru[xName]!='' && getdata.tags_ru[xName]!==null) {
         moretags.after($('<tr>').addClass('poi_moretags')
-          .append($('<td>').text(xName+': '))
+          .append($('<th>').text(xName+': '))
           .append(createListValue(getdata.tags_ru[xName])))
       }
     }
@@ -506,22 +506,23 @@ osm.poi = {
     if (moretags.length || brand) {
       ret = ret
       .append($('<div>').addClass('moretags')
-        .append($('<a>')
-          .addClass('on_button')
-          .attr('href', '#')
-          .text('Подробнее…')
-          .click(function(){
-            $(this).hide();
-            $(this.nextSibling).removeClass('off');
-            return false;
-          })
-        )
         .append($('<div>').addClass('frame off')
           .append($('<table>')
             .append(moretags)
           )
         )
-      )
+      );
+      
+      if (ret.find('tr.poi_moretags').size() > 4)
+        ret.append($('<a>')
+          .addClass('on_button')
+          .attr('href', '#')
+          .text('Подробнее…')
+          .click(function(){
+            $(this).hide().parent().find('div.frame.off').removeClass('off');
+            return false;
+          })
+        );
     }
     
     // technical info

--- a/www/js/page.map/poi.js
+++ b/www/js/page.map/poi.js
@@ -314,7 +314,7 @@ osm.poi = {
 
   createPopupText: function(getdata) {
     function createListValue(p, isDivMain, divClass, phone){
-      var out;
+      var out, list = [], maxLengthPArr = 0;
       var mainTag = (isDivMain ? '<div>' : '<td>');
       p = p.trim();
       divClass = divClass || '';
@@ -323,15 +323,18 @@ osm.poi = {
         pArr = pArr[0].split(',');
       
       if (pArr.length > 1) {
-        out = $('<ul>');
         for (var i in pArr) {
           var item = pArr[i].trim();
-          if (phone)
-            out = out.append($('<li>').append($('<a>').attr('href', 'tel:' + item)
-              .text(item.replace(/^(\+\d) (\d{3}) (\d{3})(\d{2})(\d{2})/, '$1 ($2) $3-$4-$5'))));
-          else
-            out = out.append($('<li>').text(item));
+          if (maxLengthPArr < item.length)
+            maxLengthPArr = item.length;
+          list.push(!phone ? item : $('<a>').attr('href', 'tel:' + item).text(item.replace(/^(\+\d) (\d{3}) (\d{3})(\d{2})(\d{2})/, '$1 ($2) $3-$4-$5')).html());
         }
+        
+        if (maxLengthPArr > 5)
+            out = $('<ul><li>' + list.join('</li><li>') + '</li></ul>');
+        else
+            out = list.join(', ');
+            
         out = $(mainTag).addClass(divClass).append(out);
       }
       else {


### PR DESCRIPTION
- Кнопка подробнее отображается, если количество дополнительных полей больше 4х. Решает задачи #234, #223 
- Вывод списка значений тега через запятую, если максимальная длина меньше 5. Например номера маршрутов на остановке. Иначе выводится как обычно
http://openstreetmap.ru/#map=17/55.86267/37.68455&poi=E61

![default](https://cloud.githubusercontent.com/assets/2688692/5578597/5881f11c-904c-11e4-9a2a-168a02d380b5.png)
![-1](https://cloud.githubusercontent.com/assets/2688692/5578608/b8485b72-904c-11e4-899e-22174fb1d1e2.png)
- Левая панель инструментов скрывается в мобльных браузерах. Решает задачу #230.
- Поправил визуал списка дополнительных значений. Конкретно, - прилипил их к верху, сделал название тега в th тег (жирным выводится).

В слиянии есть коммиты b6493ce и  eadf798, они были сделаны для обновления основной ветки в форке. Сделующий мердж сделаю как отдельную ветку или от мастера без этого мусора. Как последние три коммита выделить в отдельную ветку, к сожалению не знаю. Прошу принять их, или подсказать как сделать, что бы исключить их. 