### PR TITLE
Coord search

### DIFF
--- a/api/search_coordinates
+++ b/api/search_coordinates
@@ -12,6 +12,37 @@ import re
 if conf.isdebug:
   import datetime
 
+def grad2dec(grad_min_sec,delim1,delim2,delim3):
+  minutes=0
+  sec=0
+  if len(grad_min_sec.split(delim1)) == 0:
+    return 0
+  grad=int(grad_min_sec.split(delim1)[0])
+  #print("grad=",grad)
+
+  if len(grad_min_sec.split(delim1)) > 1:
+    min_sec=""
+    # склеиваем оставшиеся значения массива (актуально, если delim1==delim2==delim3 или как-то ещё)
+    min_sec_list=grad_min_sec.split(delim1)[1:]
+    for item in min_sec_list:
+      min_sec+=item+delim1
+
+    if len(min_sec.split(delim2)) > 0:
+      minutes=float(min_sec.split(delim2)[0])
+
+      if len(min_sec.split(delim2)) > 1:
+        seconds=""
+        seconds_list=min_sec.split(delim2)[1:]
+        # склеиваем оставшиеся значения массива (актуально, если delim1==delim2==delim3 или как-то ещё)
+        for item in seconds_list:
+          seconds+=item+delim2
+        if delim3 in seconds:
+          sec = float(seconds.split(delim3)[0])
+        else:
+          sec = float(seconds)
+
+  dec=grad+minutes/60+sec/3600
+  return dec
 
 def main():
   output={}
@@ -59,13 +90,44 @@ def main():
 
   lat=0
   lon=0
-  delimiters=";, :"
+  delimiters=u";, :"
 
   for delimiter in delimiters:
-    # Проверяем на соответствие координатам:
+    # Проверяем на соответствие десяичных координат:
     if re.search("-*[0-9]+\.[0-9]{1}[0-9]* *"+delimiter+" *-*[0-9]+\.[0-9]{1}[0-9]*", search_text) is not None:
   	  lat=float(search_text.split(delimiter)[0])
   	  lon=float(search_text.split(delimiter)[1])
+	  break
+    # Проверяем на соответствие координат в формате градусы°минуты'секунды":
+    delim1=u"°"
+    delim2=u"'"
+    delim3=u"\""
+    if re.search(u"-*[0-9]+"+delim1+"[0-9]+"+delim2+"[0-9]*\.*[0-9]*"+delim3+"* *"+delimiter+u"-*[0-9]+"+delim1+"[0-9]+"+delim2+"[0-9]*\.*[0-9]*"+delim3+"* *", search_text) is not None:
+      lat_grad_min_sec=search_text.split(delimiter)[0]
+      lon_grad_min_sec=search_text.split(delimiter)[1]
+      lat=grad2dec(lat_grad_min_sec,delim1,delim2,delim3)
+      lon=grad2dec(lon_grad_min_sec,delim1,delim2,delim3)
+	  break
+    # Проверяем на соответствие координат в формате градусы°минуты′секунды″:
+    delim1=u"°"
+    delim2=u"′"
+    delim3=u"″"
+    if re.search(u"-*[0-9]+"+delim1+"[0-9]+"+delim2+"[0-9]*\.*[0-9]*"+delim3+"* *"+delimiter+u"-*[0-9]+"+delim1+"[0-9]+"+delim2+"[0-9]*\.*[0-9]*"+delim3+"* *", search_text) is not None:
+      lat_grad_min_sec=search_text.split(delimiter)[0]
+      lon_grad_min_sec=search_text.split(delimiter)[1]
+      lat=grad2dec(lat_grad_min_sec,delim1,delim2,delim3)
+      lon=grad2dec(lon_grad_min_sec,delim1,delim2,delim3)
+	  break
+
+	# простая запись - взамен разделителей °'" используется один разделитель: ' (т.к. набивать с клавиатуры символ градуса неудобно):
+    delim1=u"'"
+    delim2=u"'"
+    delim3=u"'"
+    if re.search(u"-*[0-9]+"+delim1+"[0-9]+"+delim2+"[0-9]*\.*[0-9]*"+delim3+"* *"+delimiter+u"-*[0-9]+"+delim1+"[0-9]+"+delim2+"[0-9]*\.*[0-9]*"+delim3+"* *", search_text) is not None:
+      lat_grad_min_sec=search_text.split(delimiter)[0]
+      lon_grad_min_sec=search_text.split(delimiter)[1]
+      lat=grad2dec(lat_grad_min_sec,delim1,delim2,delim3)
+      lon=grad2dec(lon_grad_min_sec,delim1,delim2,delim3)
 	  break
 
   if lat==0 and lon==0:
@@ -99,6 +161,9 @@ def main():
 	  item["region_id"]=68688198
 	  output["matches"].append(item)
 
+  #if u"°" in search_text:
+  #   output['find']=True
+  #   print("equal!")
   print json.dumps(output)
 
 

--- a/api/search_coordinates
+++ b/api/search_coordinates
@@ -4,7 +4,6 @@
 # search osm
 # ErshKUS
 
-from sphinxapi import *
 import cgi, json, re, psycopg2, psycopg2.extras
 import db_config
 import api_config as conf
@@ -12,261 +11,6 @@ import re
 
 if conf.isdebug:
   import datetime
-
-def find_in_csv(search_text,result,filename,class_name):
-	for line in open(filename):
-		item={}
-		data=line.split("|")
-		item["lon"]=data[0]
-		item["lat"]=data[1]
-		item["class"]=class_name
-		item["name"]=unicode(data[2],'utf8')
-		if search_text.lower() in item["name"].lower():
-			result.append(item)	
-	return result
-
-
-def find_in_pg_by_name_ru(search_text,result):
-	conn = psycopg2.connect(host=db_config.addr_host, database=db_config.addr_database, user=db_config.addr_user, password=db_config.addr_password)
-	cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-	sql="""
-	SELECT id,class,name_ru,class_ru,osm_id,ST_X(st_centroid(c_geom)),ST_Y(st_centroid(c_geom))
-	FROM ershkus_poi
-	WHERE 
-	LOWER(name_ru) like LOWER('%%%(search)s%%')
-	""" % {"search":search_text}
-	cur.execute(sql)
-	data = cur.fetchall()
-	for line in data:
-		item={}
-		item["id"]=line["id"]
-		item["class"]=line["class"]
-		item["name"]=unicode(str(line["name_ru"]),'utf8')
-		item["class_ru"]=unicode(str(line["class_ru"]),'utf8')
-		item["osm_id"]=line["osm_id"]
-		item["lon"]=line["st_x"]
-		item["lat"]=line["st_y"]
-		result.append(item)	
-	return result
-
-def find_in_pg_by_ref(search_text,result):
-	conn = psycopg2.connect(host=db_config.addr_host, database=db_config.addr_database, user=db_config.addr_user, password=db_config.addr_password)
-	cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-	sql="""
-	SELECT id,class,ref,class_ru,osm_id,ST_X(st_centroid(c_geom)),ST_Y(st_centroid(c_geom))
-	FROM ershkus_poi
-	WHERE 
-	LOWER(ref) like LOWER('%%%(search)s%%') 
-	""" % {"search":search_text}
-	cur.execute(sql)
-	data = cur.fetchall()
-	for line in data:
-		item={}
-		item["id"]=line["id"]
-		item["class"]=line["class"]
-		item["name"]=unicode(str(line["ref"]),'utf8')
-		item["class_ru"]=unicode(str(line["class_ru"]),'utf8')
-		item["osm_id"]=line["osm_id"]
-		item["lon"]=line["st_x"]
-		item["lat"]=line["st_y"]
-		result.append(item)	
-	return result
-
-# обратный геокодинг
-def regeo(get):
-  conn = psycopg2.connect(host=db_config.addr_host, database=db_config.addr_database, user=db_config.addr_user, password=db_config.addr_password)
-  cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-  cur.execute("""
-    SELECT id, addr_type, full_name, name
-    FROM ershkus_search_addr_p
-    WHERE
-      (geom && (ST_GeomFromText('POINT(%(lon)s %(lat)s)',4326)))
-        AND ST_Covers(geom, (ST_GeomFromText('POINT(%(lon)s %(lat)s)',4326)))
-      AND (full_name is not null AND full_name <> '')
-    ORDER BY
-      addr_type_id DESC
-  """, get)
-  userPos = cur.fetchall()
-  return userPos
-
-# проверка результата поиска
-def ifresult(res, output, sphinx):
-  if not res:
-    output['error']='query failed: %s' % sphinx.GetLastError()
-    return 11
-  if sphinx.GetLastWarning():
-    output['error']='WARNING: %s\n' % sphinx.GetLastWarning()
-    return 12
-  if not res['total_found']:
-    return 1
-    
-  if checkRes(res, output):
-    return 5
-  else:
-    return 2
-  
-def checkRes(res, output):
-  pref = {'street':[u'улица',u'проспект',u'переулок',u'шоссе',u'площадь',u'бульвар',u'набережная',u'проезд']}
-  
-  if 'street' in res['matches'][0]['attrs']:
-    resW = res['matches'][0]['attrs']['street'].decode('utf-8').lower().split(' ')
-    for strResW in resW:
-      isPref = False
-      for strPref in pref['street']:
-        if strPref == strResW:
-          isPref = True
-          break
-      if isPref: continue
-      if not (output['q_check'].find(strResW)+1): return False
-  
-  return True
-
-def editGet(get, output):
-  get['q'] = ' ' + get['q'] + ' '
-  get['q'] = get['q'].lower()
-  
-  output['q_check'] = get['q'].replace(',',' ').replace('.',' ')
-
-  # дома 4-8 +-> 4/8
-  get['q'] = re.sub(u'([\s,.])(\d+)-(\d+)([\s,.])', r'\1\2-\3|\2/\3\4', get['q'])
-
-  # for street numb  '4-ая улица'
-  get['q'] = re.sub(u'( [^4-9]?\d)([-]|й|ой|ый|я|а|ая)+( )(?!корпус|строение|литер)(?=[а-яА-ЯёЁ])', ur'\1-', get['q'])
-  
-  # for house
-  # get['q'] = re.sub(u'((?:д|дом)[. ]*)(\d+)', ur'\2', get['q'])
-  get['q'] = re.sub(u'(кор(?:п|пус)[. ]*)(\d+)', ur'корпус_\2', get['q'])
-  get['q'] = re.sub(u'(ст(?:р|роение)[. ]*)(\d+)', ur'строение_\2', get['q'])
-  get['q'] = re.sub(u'(литер[а]?[. ]+)([а-яА-ЯёЁ]+)', ur'литер_\2', get['q'])
-  # short house
-  get['q'] = re.sub(u'(к)(\d+)', ur' корпус_\2 ', get['q'])
-  get['q'] = re.sub(u'(с)(\d+)', ur' строение_\2 ', get['q'])
-  get['q'] = re.sub(u'(\d)(л)([а-яА-ЯёЁ]+)', ur'\1 литер_\3 ', get['q'])
-  
-  
-  get['q'] = get['q'].replace("-",u"ъ")
-  get['q'] = get['q'].replace("/","\/")
-  get['q'] = get['q'].replace('"',r'\"')
-
-
-# поиск
-def search(get, output, sphinx):
-  output['find'] = False
-
-  # по результатом обратного геокодинга
-  if (get['lat'] or get['lon']):
-    userPos = regeo(get)
-    output['userPos'] = userPos
-    if userPos != []:
-      for row in userPos:
-        if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - firstSearch, '+row['addr_type'])
-        sphinx.ResetOnlyFilter()
-        sphinx.SetFilter(row['addr_type']+'_id', [row['id']])
-        for n in range(1,4,1):
-          if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - firstSearch, '+row['addr_type']+'-'+str(n))
-          q = '"' + get['q'] + '"~' + str(n)
-          res = sphinx.Query(q, get['sphinxindex'])
-          if ifresult(res, output, sphinx) >= 5:
-            return res
-
-        res = sphinx.Query(get['q'], get['sphinxindex'])
-        if ifresult(res, output, sphinx) >= 5:
-          return res
-
-  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - everywhere')
-  # везде
-  sphinx.ResetOnlyFilter()
-  res = sphinx.Query(get['q'], get['sphinxindex'])
-  if ifresult(res, output, sphinx) >= 5:
-    return res
-
-  # изменение запроса, в попытке найти что нужно
-   # 10 А => 10А, 10-А => 10А
-  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - 10 А=>10А')
-  q = ' ' + get['q'] + ' '
-  q=re.sub(u'(\d+)[ -]+([А-Яа-я][\s,.])', r'\1\2', q) # 10 А => 10А, 10-А => 10А
-  res1 = sphinx.Query(q, get['sphinxindex'])
-  if ifresult(res1, output, sphinx) >= 5:
-    return res1
-
-  # уменьшения количества значущих слов
-  if conf.isdebug:
-    output['debug']['test_big_len'] = {}
-    output['debug']['test-timer'].append(str(datetime.datetime.now())+' - significant words, words:'+str(len(res['words'])))
-  for n in range(len(res['words'])-1, max(len(res['words'])-8,0), -1):
-    q = '"' + get['q'] + '"/' + str(n)
-    if conf.isdebug:
-      output['debug']['test_big_len'][n] = {}
-      output['debug']['test_big_len'][n]['q'] = q
-    res1 = sphinx.Query(q, get['sphinxindex'])
-    if conf.isdebug:
-      output['debug']['test_big_len'][n]['ifresult'] = ifresult(res1, output, sphinx)
-    if ifresult(res1, output, sphinx) >= 5:
-      if ifresult(res1, output, sphinx) == 5 and res1['matches'][0]['attrs']['addr_type_id'] >= 35:
-        return ifReturnHouse(res1, get, output, sphinx, n, len(res['words']))
-      return res1
-
-  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - end search')
-  return res
-
-# обработка если нет дома
-def ifReturnHouse(res1, get, output, sphinx, pos, words):
-  if conf.isdebug:
-    output['debug']['test-ifRH']={}
-  for n in range(pos-1, 0, -1):
-    q = '"' + get['q'] + '"/' + str(n)
-    if conf.isdebug:
-      output['debug']['test-ifRH'][n]={}
-      output['debug']['test-ifRH'][n]['q']=q
-    res2 = sphinx.Query(q, get['sphinxindex'])
-    if ifresult(res2, output, sphinx) == 2 and res2['matches'][0]['attrs']['addr_type_id'] < 35:
-      if conf.isdebug:
-        output['debug']['test-ifRH'][n]['res2']=res2
-      sphinx.ResetOnlyFilter()
-      for addr_type in ['country', 'region', 'district', 'city', 'village', 'street']:
-        if addr_type == res2['matches'][0]['attrs']['addr_type']:
-          sphinx.SetFilter(addr_type+'_id', [res2['matches'][0]['id']])
-        else:
-          sphinx.SetFilter(addr_type+'_id', [res2['matches'][0]['attrs'][addr_type+'_id']])
-      
-      if conf.isdebug:
-        output['debug']['test-ifRH'][n]['filters'] = sphinx._filters
-      
-      for n2 in range(words-1, 0, -1):
-        q2 = '"' + get['q'] + '"/' + str(n2)
-        if conf.isdebug:
-          output['debug']['test-ifRH'][n][n2]={}
-          output['debug']['test-ifRH'][n][n2]['q2']=q2
-        res3 = sphinx.Query(q2, get['sphinxindex'])
-        if conf.isdebug:
-          output['debug']['test-ifRH'][n][n2]['res3']=res3
-        if ifresult(res3, output, sphinx) >= 2:
-          if conf.isdebug:
-            output['debug']['test-ifRH'][n][n2]['res3_']=1
-          return res3
-  return res1
-
-# вывод результатов
-def report(res, output, get, sphinx):
-  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - def report')
-  if conf.isdebug: output['debug']['res-report'] = res
-  if ifresult(res, output, sphinx) == 5:
-    output['find']=True
-    outputdata=[]
-    for match in res['matches']:
-      if match['attrs']['addr_type_id']<=res['matches'][0]['attrs']['addr_type_id']:
-        outputlen=match['attrs']
-        outputlen['id']=match['id']
-        outputlen['weight']=match['weight']
-        if not get['asis']: # экранирование html спецсимволов
-          outputlen['display_name'] = outputlen['display_name'].replace('&','&amp;')
-          outputlen['display_name'] = outputlen['display_name'].replace('\"',"&quot;")
-          outputlen['display_name'] = outputlen['display_name'].replace('\'','&#039;')
-          outputlen['display_name'] = outputlen['display_name'].replace('<','&lt;')
-          outputlen['display_name'] = outputlen['display_name'].replace('>','&gt;')
-        outputdata.append(outputlen)
-
-    output['matches']=outputdata
 
 
 def main():
@@ -308,17 +52,6 @@ def main():
     output['search'] = output['search'].replace('<','&lt;')
     output['search'] = output['search'].replace('>','&gt;')
 
-  if get['st'] == 'all':
-    get['sphinxindex'] = conf.sphinx_index_addr + ' , ' + conf.sphinx_index_poi
-  elif get['st'] == 'addr':
-    get['sphinxindex'] = conf.sphinx_index_addr
-  elif get['st'] == 'poi':
-    get['sphinxindex'] = conf.sphinx_index_poi
-  else:
-    output['error']="no query words, 'st' is 'all' or 'addr' or 'poi'"
-    return
-
-  # Ищем в текстовых файлах:
   output['find']=False
   output["matches"]=[]
 
@@ -331,9 +64,9 @@ def main():
   for delimiter in delimiters:
     # Проверяем на соответствие координатам:
     if re.search("-*[0-9]+\.[0-9]{1}[0-9]* *"+delimiter+" *-*[0-9]+\.[0-9]{1}[0-9]*", search_text) is not None:
-      lat=float(search_text.split(delimiter)[0])
-      lon=float(search_text.split(delimiter)[1])
-      break
+  	  lat=float(search_text.split(delimiter)[0])
+  	  lon=float(search_text.split(delimiter)[1])
+	  break
 
   if lat==0 and lon==0:
 	  output['find']=False

--- a/api/search_coordinates
+++ b/api/search_coordinates
@@ -326,52 +326,14 @@ def main():
 
   lat=0
   lon=0
-  # Проверяем на соответствие координатам:
-  if re.search('[0-9]{2}\.[0-9]{3}[0-9]*,[0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(',')[0])
-  	lon=float(search_text.split(',')[1])
-  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]*,[0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(',')[1])
-  	lon=float(search_text.split(',')[0])
+  delimiters=";, :"
 
-  elif re.search('[0-9]{2}\.[0-9]{3}[0-9]* [0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(' ')[0])
-  	lon=float(search_text.split(' ')[1])
-  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]* [0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(' ')[1])
-  	lon=float(search_text.split(' ')[0])
-  elif re.search('[0-9]{2},[0-9]{3}[0-9]* [0-9]{3},[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(' ')[0].replace(",","."))
-  	lon=float(search_text.split(' ')[1].replace(",","."))
-  elif re.search('[0-9]{3},[0-9]{3}[0-9]* [0-9]{2},[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(' ')[1].replace(",","."))
-  	lon=float(search_text.split(' ')[0].replace(",","."))
-
-  elif re.search('[0-9]{2}\.[0-9]{3}[0-9]*:[0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(':')[0])
-  	lon=float(search_text.split(':')[1])
-  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]*:[0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(':')[1])
-  	lon=float(search_text.split(':')[0])
-  elif re.search('[0-9]{2},[0-9]{3}[0-9]*:[0-9]{3},[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(':')[0].replace(",","."))
-  	lon=float(search_text.split(':')[1].replace(",","."))
-  elif re.search('[0-9]{3},[0-9]{3}[0-9]*:[0-9]{2},[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(':')[1].replace(",","."))
-  	lon=float(search_text.split(':')[0].replace(",","."))
-
-  elif re.search('[0-9]{2}\.[0-9]{3}[0-9]*;[0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(';')[0])
-  	lon=float(search_text.split(';')[1])
-  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]*;[0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(';')[1])
-  	lon=float(search_text.split(';')[0])
-  elif re.search('[0-9]{2},[0-9]{3}[0-9]*;[0-9]{3},[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(';')[0].replace(",","."))
-  	lon=float(search_text.split(';')[1].replace(",","."))
-  elif re.search('[0-9]{3},[0-9]{3}[0-9]*;[0-9]{2},[0-9]{3}[0-9]*', search_text) is not None:
-  	lat=float(search_text.split(';')[1].replace(",","."))
-  	lon=float(search_text.split(';')[0].replace(",","."))
+  for delimiter in delimiters:
+    # Проверяем на соответствие координатам:
+    if re.search("-*[0-9]+\.[0-9]{1}[0-9]* *"+delimiter+" *-*[0-9]+\.[0-9]{1}[0-9]*", search_text) is not None:
+      lat=float(search_text.split(delimiter)[0])
+      lon=float(search_text.split(delimiter)[1])
+      break
 
   if lat==0 and lon==0:
 	  output['find']=False

--- a/api/search_coordinates
+++ b/api/search_coordinates
@@ -1,0 +1,411 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+
+# search osm
+# ErshKUS
+
+from sphinxapi import *
+import cgi, json, re, psycopg2, psycopg2.extras
+import db_config
+import api_config as conf
+import re
+
+if conf.isdebug:
+  import datetime
+
+def find_in_csv(search_text,result,filename,class_name):
+	for line in open(filename):
+		item={}
+		data=line.split("|")
+		item["lon"]=data[0]
+		item["lat"]=data[1]
+		item["class"]=class_name
+		item["name"]=unicode(data[2],'utf8')
+		if search_text.lower() in item["name"].lower():
+			result.append(item)	
+	return result
+
+
+def find_in_pg_by_name_ru(search_text,result):
+	conn = psycopg2.connect(host=db_config.addr_host, database=db_config.addr_database, user=db_config.addr_user, password=db_config.addr_password)
+	cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+	sql="""
+	SELECT id,class,name_ru,class_ru,osm_id,ST_X(st_centroid(c_geom)),ST_Y(st_centroid(c_geom))
+	FROM ershkus_poi
+	WHERE 
+	LOWER(name_ru) like LOWER('%%%(search)s%%')
+	""" % {"search":search_text}
+	cur.execute(sql)
+	data = cur.fetchall()
+	for line in data:
+		item={}
+		item["id"]=line["id"]
+		item["class"]=line["class"]
+		item["name"]=unicode(str(line["name_ru"]),'utf8')
+		item["class_ru"]=unicode(str(line["class_ru"]),'utf8')
+		item["osm_id"]=line["osm_id"]
+		item["lon"]=line["st_x"]
+		item["lat"]=line["st_y"]
+		result.append(item)	
+	return result
+
+def find_in_pg_by_ref(search_text,result):
+	conn = psycopg2.connect(host=db_config.addr_host, database=db_config.addr_database, user=db_config.addr_user, password=db_config.addr_password)
+	cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+	sql="""
+	SELECT id,class,ref,class_ru,osm_id,ST_X(st_centroid(c_geom)),ST_Y(st_centroid(c_geom))
+	FROM ershkus_poi
+	WHERE 
+	LOWER(ref) like LOWER('%%%(search)s%%') 
+	""" % {"search":search_text}
+	cur.execute(sql)
+	data = cur.fetchall()
+	for line in data:
+		item={}
+		item["id"]=line["id"]
+		item["class"]=line["class"]
+		item["name"]=unicode(str(line["ref"]),'utf8')
+		item["class_ru"]=unicode(str(line["class_ru"]),'utf8')
+		item["osm_id"]=line["osm_id"]
+		item["lon"]=line["st_x"]
+		item["lat"]=line["st_y"]
+		result.append(item)	
+	return result
+
+# обратный геокодинг
+def regeo(get):
+  conn = psycopg2.connect(host=db_config.addr_host, database=db_config.addr_database, user=db_config.addr_user, password=db_config.addr_password)
+  cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+  cur.execute("""
+    SELECT id, addr_type, full_name, name
+    FROM ershkus_search_addr_p
+    WHERE
+      (geom && (ST_GeomFromText('POINT(%(lon)s %(lat)s)',4326)))
+        AND ST_Covers(geom, (ST_GeomFromText('POINT(%(lon)s %(lat)s)',4326)))
+      AND (full_name is not null AND full_name <> '')
+    ORDER BY
+      addr_type_id DESC
+  """, get)
+  userPos = cur.fetchall()
+  return userPos
+
+# проверка результата поиска
+def ifresult(res, output, sphinx):
+  if not res:
+    output['error']='query failed: %s' % sphinx.GetLastError()
+    return 11
+  if sphinx.GetLastWarning():
+    output['error']='WARNING: %s\n' % sphinx.GetLastWarning()
+    return 12
+  if not res['total_found']:
+    return 1
+    
+  if checkRes(res, output):
+    return 5
+  else:
+    return 2
+  
+def checkRes(res, output):
+  pref = {'street':[u'улица',u'проспект',u'переулок',u'шоссе',u'площадь',u'бульвар',u'набережная',u'проезд']}
+  
+  if 'street' in res['matches'][0]['attrs']:
+    resW = res['matches'][0]['attrs']['street'].decode('utf-8').lower().split(' ')
+    for strResW in resW:
+      isPref = False
+      for strPref in pref['street']:
+        if strPref == strResW:
+          isPref = True
+          break
+      if isPref: continue
+      if not (output['q_check'].find(strResW)+1): return False
+  
+  return True
+
+def editGet(get, output):
+  get['q'] = ' ' + get['q'] + ' '
+  get['q'] = get['q'].lower()
+  
+  output['q_check'] = get['q'].replace(',',' ').replace('.',' ')
+
+  # дома 4-8 +-> 4/8
+  get['q'] = re.sub(u'([\s,.])(\d+)-(\d+)([\s,.])', r'\1\2-\3|\2/\3\4', get['q'])
+
+  # for street numb  '4-ая улица'
+  get['q'] = re.sub(u'( [^4-9]?\d)([-]|й|ой|ый|я|а|ая)+( )(?!корпус|строение|литер)(?=[а-яА-ЯёЁ])', ur'\1-', get['q'])
+  
+  # for house
+  # get['q'] = re.sub(u'((?:д|дом)[. ]*)(\d+)', ur'\2', get['q'])
+  get['q'] = re.sub(u'(кор(?:п|пус)[. ]*)(\d+)', ur'корпус_\2', get['q'])
+  get['q'] = re.sub(u'(ст(?:р|роение)[. ]*)(\d+)', ur'строение_\2', get['q'])
+  get['q'] = re.sub(u'(литер[а]?[. ]+)([а-яА-ЯёЁ]+)', ur'литер_\2', get['q'])
+  # short house
+  get['q'] = re.sub(u'(к)(\d+)', ur' корпус_\2 ', get['q'])
+  get['q'] = re.sub(u'(с)(\d+)', ur' строение_\2 ', get['q'])
+  get['q'] = re.sub(u'(\d)(л)([а-яА-ЯёЁ]+)', ur'\1 литер_\3 ', get['q'])
+  
+  
+  get['q'] = get['q'].replace("-",u"ъ")
+  get['q'] = get['q'].replace("/","\/")
+  get['q'] = get['q'].replace('"',r'\"')
+
+
+# поиск
+def search(get, output, sphinx):
+  output['find'] = False
+
+  # по результатом обратного геокодинга
+  if (get['lat'] or get['lon']):
+    userPos = regeo(get)
+    output['userPos'] = userPos
+    if userPos != []:
+      for row in userPos:
+        if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - firstSearch, '+row['addr_type'])
+        sphinx.ResetOnlyFilter()
+        sphinx.SetFilter(row['addr_type']+'_id', [row['id']])
+        for n in range(1,4,1):
+          if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - firstSearch, '+row['addr_type']+'-'+str(n))
+          q = '"' + get['q'] + '"~' + str(n)
+          res = sphinx.Query(q, get['sphinxindex'])
+          if ifresult(res, output, sphinx) >= 5:
+            return res
+
+        res = sphinx.Query(get['q'], get['sphinxindex'])
+        if ifresult(res, output, sphinx) >= 5:
+          return res
+
+  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - everywhere')
+  # везде
+  sphinx.ResetOnlyFilter()
+  res = sphinx.Query(get['q'], get['sphinxindex'])
+  if ifresult(res, output, sphinx) >= 5:
+    return res
+
+  # изменение запроса, в попытке найти что нужно
+   # 10 А => 10А, 10-А => 10А
+  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - 10 А=>10А')
+  q = ' ' + get['q'] + ' '
+  q=re.sub(u'(\d+)[ -]+([А-Яа-я][\s,.])', r'\1\2', q) # 10 А => 10А, 10-А => 10А
+  res1 = sphinx.Query(q, get['sphinxindex'])
+  if ifresult(res1, output, sphinx) >= 5:
+    return res1
+
+  # уменьшения количества значущих слов
+  if conf.isdebug:
+    output['debug']['test_big_len'] = {}
+    output['debug']['test-timer'].append(str(datetime.datetime.now())+' - significant words, words:'+str(len(res['words'])))
+  for n in range(len(res['words'])-1, max(len(res['words'])-8,0), -1):
+    q = '"' + get['q'] + '"/' + str(n)
+    if conf.isdebug:
+      output['debug']['test_big_len'][n] = {}
+      output['debug']['test_big_len'][n]['q'] = q
+    res1 = sphinx.Query(q, get['sphinxindex'])
+    if conf.isdebug:
+      output['debug']['test_big_len'][n]['ifresult'] = ifresult(res1, output, sphinx)
+    if ifresult(res1, output, sphinx) >= 5:
+      if ifresult(res1, output, sphinx) == 5 and res1['matches'][0]['attrs']['addr_type_id'] >= 35:
+        return ifReturnHouse(res1, get, output, sphinx, n, len(res['words']))
+      return res1
+
+  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - end search')
+  return res
+
+# обработка если нет дома
+def ifReturnHouse(res1, get, output, sphinx, pos, words):
+  if conf.isdebug:
+    output['debug']['test-ifRH']={}
+  for n in range(pos-1, 0, -1):
+    q = '"' + get['q'] + '"/' + str(n)
+    if conf.isdebug:
+      output['debug']['test-ifRH'][n]={}
+      output['debug']['test-ifRH'][n]['q']=q
+    res2 = sphinx.Query(q, get['sphinxindex'])
+    if ifresult(res2, output, sphinx) == 2 and res2['matches'][0]['attrs']['addr_type_id'] < 35:
+      if conf.isdebug:
+        output['debug']['test-ifRH'][n]['res2']=res2
+      sphinx.ResetOnlyFilter()
+      for addr_type in ['country', 'region', 'district', 'city', 'village', 'street']:
+        if addr_type == res2['matches'][0]['attrs']['addr_type']:
+          sphinx.SetFilter(addr_type+'_id', [res2['matches'][0]['id']])
+        else:
+          sphinx.SetFilter(addr_type+'_id', [res2['matches'][0]['attrs'][addr_type+'_id']])
+      
+      if conf.isdebug:
+        output['debug']['test-ifRH'][n]['filters'] = sphinx._filters
+      
+      for n2 in range(words-1, 0, -1):
+        q2 = '"' + get['q'] + '"/' + str(n2)
+        if conf.isdebug:
+          output['debug']['test-ifRH'][n][n2]={}
+          output['debug']['test-ifRH'][n][n2]['q2']=q2
+        res3 = sphinx.Query(q2, get['sphinxindex'])
+        if conf.isdebug:
+          output['debug']['test-ifRH'][n][n2]['res3']=res3
+        if ifresult(res3, output, sphinx) >= 2:
+          if conf.isdebug:
+            output['debug']['test-ifRH'][n][n2]['res3_']=1
+          return res3
+  return res1
+
+# вывод результатов
+def report(res, output, get, sphinx):
+  if conf.isdebug: output['debug']['test-timer'].append(str(datetime.datetime.now())+' - def report')
+  if conf.isdebug: output['debug']['res-report'] = res
+  if ifresult(res, output, sphinx) == 5:
+    output['find']=True
+    outputdata=[]
+    for match in res['matches']:
+      if match['attrs']['addr_type_id']<=res['matches'][0]['attrs']['addr_type_id']:
+        outputlen=match['attrs']
+        outputlen['id']=match['id']
+        outputlen['weight']=match['weight']
+        if not get['asis']: # экранирование html спецсимволов
+          outputlen['display_name'] = outputlen['display_name'].replace('&','&amp;')
+          outputlen['display_name'] = outputlen['display_name'].replace('\"',"&quot;")
+          outputlen['display_name'] = outputlen['display_name'].replace('\'','&#039;')
+          outputlen['display_name'] = outputlen['display_name'].replace('<','&lt;')
+          outputlen['display_name'] = outputlen['display_name'].replace('>','&gt;')
+        outputdata.append(outputlen)
+
+    output['matches']=outputdata
+
+
+def main():
+  output={}
+  output['ver']='0.7'
+  if conf.isdebug:
+    output['debug']={}
+    output['debug']['test-timer']=[]
+    output['debug']['test-timer'].append(str(datetime.datetime.now())+' - 1')
+
+
+  getvalues=cgi.FieldStorage()
+  get={}
+  get['outCallback'] = getvalues.getfirst('callback','')
+
+  print "Content-type: text/javascript; Charset=Utf-8\nAccess-Control-Allow-Origin: *\n" # debug
+  #print "Content-type: application/json; Charset=Utf-8\nAccess-Control-Allow-Origin: *\n" # production
+
+  get['q'] = unicode(getvalues.getfirst("q",""),'utf8') # строка поиска
+  get['lat'] = float(getvalues.getfirst("lat","0")) # координаты куда смотрит пользователь
+  get['lon'] = float(getvalues.getfirst("lon","0")) # координаты куда смотрит пользователь
+  get['asis'] = bool(getvalues.getfirst("asis","1")) # не экранировать спецсимволы html при выводе результатов
+  get['nolimit'] = bool(getvalues.getfirst("nolimit","")) # не ограничивать количество выводимых результатов поиска
+  get['cnt'] = int(getvalues.getfirst("cnt","12")) # число выводимых результатов поиска
+  get['st'] = unicode(getvalues.getfirst("st","")) # [all / addr / poi]  где ищем
+  if get['st'] == "":
+    get['st'] = unicode(getvalues.getfirst("stype","all")) # all / addr / poi (поддержка старого названия)
+  output['in'] = get.copy()
+
+  if not get['q']:
+    output['error']="no query words, 'q' is empty"
+    return
+
+  output['search'] = get['q']
+  if not get['asis']: # экранирование html спецсимволов
+    output['search'] = output['search'].replace('&','&amp;')
+    output['search'] = output['search'].replace('\"',"&quot;")
+    output['search'] = output['search'].replace('\'','&#039;')
+    output['search'] = output['search'].replace('<','&lt;')
+    output['search'] = output['search'].replace('>','&gt;')
+
+  if get['st'] == 'all':
+    get['sphinxindex'] = conf.sphinx_index_addr + ' , ' + conf.sphinx_index_poi
+  elif get['st'] == 'addr':
+    get['sphinxindex'] = conf.sphinx_index_addr
+  elif get['st'] == 'poi':
+    get['sphinxindex'] = conf.sphinx_index_poi
+  else:
+    output['error']="no query words, 'st' is 'all' or 'addr' or 'poi'"
+    return
+
+  # Ищем в текстовых файлах:
+  output['find']=False
+  output["matches"]=[]
+
+  search_text=get['q']
+
+  lat=0
+  lon=0
+  # Проверяем на соответствие координатам:
+  if re.search('[0-9]{2}\.[0-9]{3}[0-9]*,[0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(',')[0])
+  	lon=float(search_text.split(',')[1])
+  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]*,[0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(',')[1])
+  	lon=float(search_text.split(',')[0])
+
+  elif re.search('[0-9]{2}\.[0-9]{3}[0-9]* [0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(' ')[0])
+  	lon=float(search_text.split(' ')[1])
+  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]* [0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(' ')[1])
+  	lon=float(search_text.split(' ')[0])
+  elif re.search('[0-9]{2},[0-9]{3}[0-9]* [0-9]{3},[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(' ')[0].replace(",","."))
+  	lon=float(search_text.split(' ')[1].replace(",","."))
+  elif re.search('[0-9]{3},[0-9]{3}[0-9]* [0-9]{2},[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(' ')[1].replace(",","."))
+  	lon=float(search_text.split(' ')[0].replace(",","."))
+
+  elif re.search('[0-9]{2}\.[0-9]{3}[0-9]*:[0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(':')[0])
+  	lon=float(search_text.split(':')[1])
+  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]*:[0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(':')[1])
+  	lon=float(search_text.split(':')[0])
+  elif re.search('[0-9]{2},[0-9]{3}[0-9]*:[0-9]{3},[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(':')[0].replace(",","."))
+  	lon=float(search_text.split(':')[1].replace(",","."))
+  elif re.search('[0-9]{3},[0-9]{3}[0-9]*:[0-9]{2},[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(':')[1].replace(",","."))
+  	lon=float(search_text.split(':')[0].replace(",","."))
+
+  elif re.search('[0-9]{2}\.[0-9]{3}[0-9]*;[0-9]{3}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(';')[0])
+  	lon=float(search_text.split(';')[1])
+  elif re.search('[0-9]{3}\.[0-9]{3}[0-9]*;[0-9]{2}\.[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(';')[1])
+  	lon=float(search_text.split(';')[0])
+  elif re.search('[0-9]{2},[0-9]{3}[0-9]*;[0-9]{3},[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(';')[0].replace(",","."))
+  	lon=float(search_text.split(';')[1].replace(",","."))
+  elif re.search('[0-9]{3},[0-9]{3}[0-9]*;[0-9]{2},[0-9]{3}[0-9]*', search_text) is not None:
+  	lat=float(search_text.split(';')[1].replace(",","."))
+  	lon=float(search_text.split(';')[0].replace(",","."))
+
+  if lat==0 and lon==0:
+	  output['find']=False
+  else:
+	  output['find']=True
+      # userPos:
+	  count=1
+	  # matches:
+	  item={}
+	  item["lon"]=lon
+	  item["lat"]=lat
+	  item["name"]=search_text
+	  item["display_name"]="%f, %f" % (lat, lon)
+	  item["full_name"]=""
+	  item["id"]=1
+	  item["osm_id"]=1
+	  item["class"]="class"
+	  
+	  item["street_id"]=0
+	  item["village_id"]=0
+	  item["city_id"]=0
+	  item["weight"]=2000
+	  item["addr_type_id"]=70
+	  item["country_id"]=0
+	  item["district_id"]=0
+	  item["this_poi"]=1
+	  item["addr_type"]="poi"
+	  item["operator"]=""
+	  item["@geodist"]=7986888.5
+	  item["region_id"]=68688198
+	  output["matches"].append(item)
+
+  print json.dumps(output)
+
+
+if __name__ == '__main__':
+  main()

--- a/www/js/page.map/osm.utils.search.js
+++ b/www/js/page.map/osm.utils.search.js
@@ -225,6 +225,14 @@ search.startSearch = function() {
       lon: center.lng
     }, search.processResults).error(search.errorHandler);
 
+  $.getJSON('api/search_coordinates', {
+      q: q,
+      stype: st,
+      accuracy: 1,
+	  cnt: 20,
+      lat: center.lat,
+      lon: center.lng
+    }, search.processCoordResults).error(search.errorHandler);
   $.getJSON('http://open.mapquestapi.com/nominatim/v1/search.php', {
       q: q,
       format: 'json',

--- a/www/map.php
+++ b/www/map.php
@@ -56,6 +56,7 @@ $page_content = <<<PHP_CONTENT
       <div id="leftsearch" class="leftgroup" style="display: none;">
         <h1>Поиск <img class="loader" src="/img/loader.gif" alt=""></h1>
         <div class="leftcontent" style="display: none;">
+          <div class="coordsearch"></div>
           <div class="mainsearch"></div>
           <div class="othersearch"></div>
         </div>


### PR DESCRIPTION
Поддержка поиска по координатам (десятичным и град/мин/сек).
Если в строке поиска ввести что либо вида:
43.15 132.01
или (разделители - символы одинарного и двойного апострова):
43°9′0″ 132°0′36″
или (разделители - символы одинарной и двойной кавычек):
43°9'0" 132°0'36"

или всё то же самое, но разделитель между lat и lon не пробел, а ';' или ':' или ',', окружённый или нет пробелами),

То в списке поиска появится переход на соответствующие координаты.
Порою это бывает нужно. Вводить в строке адреса крайне неудобно. Более того, порою в интернете координаты даются именно в град/мин/сек.

